### PR TITLE
Makes publish job start after build job

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -55,6 +55,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish actions
+    needs: build
 
     # Only run publishing on commits that perform versioning
     if: ${{ startsWith(github.event.commits[0].message, 'Version Packages') }}


### PR DESCRIPTION
This PR fixes an issue with the build-and-publish workflow where both the build and publish jobs would start at the same time, publish should wait for build to finish.