### PR TITLE
Adds workflow to update dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,20 @@
+name: Renovate
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+  workflow_dispatch:
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.2
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v29.36.2
+        with:
+          configurationFile: renovate-config.js
+          token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        env:
+          LOG_LEVEL: debug


### PR DESCRIPTION
This PR adds a new github workflow to automate updating of dependencies using renovate. The renovate config already existed, this just runs it. The workflow is scheduled to run once a day.