### PR TITLE
Update renovate to latest version

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2.4.2
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v29.36.2
+        uses: renovatebot/github-action@v32.48.0
         with:
           configurationFile: renovate-config.js
           token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}


### PR DESCRIPTION
We've been seeing some build failures with PRs that are opened by renovate where they report an error on `pnpm install`: `Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up-to-date with package.json`. This appears to be due to [this issue](https://github.com/renovatebot/renovate/issues/8323) which is fixed.

This PR updates to the latest renovate action to attempt to fix the issue.