### PR TITLE
Configures renovate to use pnpm 6

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,6 +11,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.4.2
 
+      # Note: Renovate runs within it's own docker container and doesn't 
+      # know really anything about which version of tooling are in use e.g. pnpm
+      # it just uses the latest version. This could potentially cause issues if
+      # a new major version of pnpm gets released, so we have a constraint in
+      # the renovate-config.js file to restrict it to use v6 to align with us.
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@v29.36.2
         with:

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -23,4 +23,7 @@ module.exports = {
     timezone: "Australia/Brisbane",
     onboarding: false,
     requireConfig: false,
+    constraints: {
+        pnpm: "< 7.0.0",
+    },
 };

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -26,6 +26,7 @@ module.exports = {
     constraints: {
         pnpm: "< 7.0.0",
     },
+    allowedPostUpgradeCommands: ["pnpm build"],
     postUpgradeTasks: {
         commands: ["pnpm build"],
         fileFilters: ["**/index.js"],

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -26,9 +26,9 @@ module.exports = {
     constraints: {
         pnpm: "< 7.0.0",
     },
-    allowedPostUpgradeCommands: ["pnpm build"],
+    allowedPostUpgradeCommands: [".*"],
     postUpgradeTasks: {
-        commands: ["pnpm build"],
+        commands: ["npm i -g pnpm@'< 7.0.0' && pnpm install && pnpm build"],
         fileFilters: ["**/index.js"],
         executionMode: "update"
     }

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -26,4 +26,9 @@ module.exports = {
     constraints: {
         pnpm: "< 7.0.0",
     },
+    postUpgradeTasks: {
+        commands: ["pnpm build"],
+        fileFilters: ["**/index.js"],
+        executionMode: "update"
+    }
 };


### PR DESCRIPTION
We've been seeing some build failures with PRs that are opened by renovate where they report an error on `pnpm install`: `Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up-to-date with package.json`. 

This appears to be because a new major version of pnpm got release (v7) and potentially there are some subtle differences in the way the `pnpm install` command works which the version of renovate we are using (v29) doesn't seem to be compatible with. We could consider updating to the latest version of renovate as there appears to be a fix for it against [this issue](https://github.com/renovatebot/renovate/issues/8323) however we would still be left with renovate using a different major version of pnpm to us which feels not ideal.

This PR adds a constraint to the renovate config to indicate that we want to use pnpm v6.

This PR also adds a post upgrade task to install pnpm and run `pnpm build` so that we can update the transpiled js as part of the created PR.