### PR TITLE
Update repo to build with pnpm v7

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "16.*"
+          node-version: "14.*"
           cache: "pnpm"
 
       # Why do we explicitly do pnpm install here and not use "run_install: true" above in the pnpm setup?
@@ -72,7 +72,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "16.*"
+          node-version: "14.*"
           cache: "pnpm"
 
       # Why do we explicitly do pnpm install here and not use "run_install: true" above in the pnpm setup?

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.10
+          version: 7.9.5
 
       - name: setup node
         uses: actions/setup-node@v2
@@ -67,7 +67,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.10
+          version: 7.9.5
 
       - name: setup node
         uses: actions/setup-node@v2

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "14.*"
+          node-version: "16.*"
           cache: "pnpm"
 
       # Why do we explicitly do pnpm install here and not use "run_install: true" above in the pnpm setup?

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -72,7 +72,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "14.*"
+          node-version: "16.*"
           cache: "pnpm"
 
       # Why do we explicitly do pnpm install here and not use "run_install: true" above in the pnpm setup?

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "16.*"
+          node-version: "14.*"
           cache: "pnpm"
 
       # Why do we explicitly do pnpm install here and not use "run_install: true" above in the pnpm setup?

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: "14.*"
+          node-version: "16.*"
           cache: "pnpm"
 
       # Why do we explicitly do pnpm install here and not use "run_install: true" above in the pnpm setup?

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.10
+          version: 7.9.5
 
       - name: setup node
         uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "pnpm --filter={packages/*} run test"
   },
   "engines": {
-    "node": "^14.0.0",
+    "node": "^16.0.0",
     "pnpm": "^7.9.5",
     "npm": "not-supported.please-use-pnpm-instead"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "preinstall": "npx only-allow pnpm",
     "test": "pnpm --filter={packages/*} run test"
   },
+  "engines": {
+    "node": "^14.0.0",
+    "pnpm": "^7.9.5",
+    "npm": "not-supported.please-use-pnpm-instead"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OctopusDeploy/util-actions.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A set of utility actions for use in GitHub actions workflows",
   "main": "index.js",
   "scripts": {
-    "build": "pnpm run build --filter={packages}",
+    "build": "pnpm --filter={packages/*} run build",
     "changeset": "changeset",
     "ci:version": "pnpm run changeset version && pnpm install --frozen-lockfile=false",
     "ci:checkdist": "node ./packages/shared-action-utils/dist/checkActionDistributable.js",
@@ -12,7 +12,7 @@
     "lint:fix": "eslint . --fix",
     "lint": "eslint . --no-error-on-unmatched-pattern",
     "preinstall": "npx only-allow pnpm",
-    "test": "pnpm run test --filter={packages}"
+    "test": "pnpm --filter={packages/*} run test"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -17,14 +17,14 @@ importers:
       typescript: 4.6.4
     devDependencies:
       '@changesets/cli': 2.22.0
-      '@typescript-eslint/eslint-plugin': 5.42.0_cf2448fba32f5cacd6a7d2d9b63f7cb6
-      '@typescript-eslint/parser': 5.42.0_eslint@8.26.0+typescript@4.6.4
+      '@typescript-eslint/eslint-plugin': 5.42.0_z4ser65df5okzvvh2lm3mp34wy
+      '@typescript-eslint/parser': 5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4
       eslint: 8.26.0
       eslint-config-prettier: 8.5.0_eslint@8.26.0
-      eslint-plugin-import: 2.26.0_e8080e8dfc6eb6c2d798d3189bb964d9
-      eslint-plugin-jest: 26.9.0_89d29be57054bf0fbb433898cb8f1a9d
+      eslint-plugin-import: 2.26.0_5aea5dp4n23mfv4y2mmjxole3e
+      eslint-plugin-jest: 26.9.0_rhjjxzlqks7q7o2dhcmmxdy2tu
       eslint-plugin-prefer-arrow: 1.2.3_eslint@8.26.0
-      eslint-plugin-prettier: 4.2.1_e1e64d52f64ca2fc626d6040e4e5aafc
+      eslint-plugin-prettier: 4.2.1_4hte2uxwjsrpyytnmbaojznk7q
       prettier: 2.6.2
       typescript: 4.6.4
 
@@ -59,8 +59,8 @@ importers:
       jest: 26.6.3
       jest-expect-message: 1.1.3
       jest-extended: 1.2.1
-      jest-runner-eslint: 1.1.0_eslint@8.26.0+jest@26.6.3
-      ts-jest: 26.5.6_jest@26.6.3+typescript@4.6.4
+      jest-runner-eslint: 1.1.0_jest@26.6.3
+      ts-jest: 26.5.6_ip4jai7pxkumsngma2fb7ud2tm
       typescript: 4.6.4
 
   packages/extract-package-details:
@@ -86,8 +86,8 @@ importers:
       jest: 26.6.3
       jest-expect-message: 1.1.3
       jest-extended: 1.2.1
-      jest-runner-eslint: 1.1.0_eslint@8.26.0+jest@26.6.3
-      ts-jest: 26.5.6_jest@26.6.3+typescript@4.6.4
+      jest-runner-eslint: 1.1.0_jest@26.6.3
+      ts-jest: 26.5.6_ip4jai7pxkumsngma2fb7ud2tm
       typescript: 4.6.4
 
   packages/find-and-replace-all:
@@ -113,8 +113,8 @@ importers:
       jest: 26.6.3
       jest-expect-message: 1.1.3
       jest-extended: 1.2.1
-      jest-runner-eslint: 1.1.0_eslint@8.26.0+jest@26.6.3
-      ts-jest: 26.5.6_jest@26.6.3+typescript@4.6.4
+      jest-runner-eslint: 1.1.0_jest@26.6.3
+      ts-jest: 26.5.6_ip4jai7pxkumsngma2fb7ud2tm
       typescript: 4.6.4
 
   packages/shared-action-utils:
@@ -1146,7 +1146,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.42.0_cf2448fba32f5cacd6a7d2d9b63f7cb6:
+  /@typescript-eslint/eslint-plugin/5.42.0_z4ser65df5okzvvh2lm3mp34wy:
     resolution: {integrity: sha512-5TJh2AgL6+wpL8H/GTSjNb4WrjKoR2rqvFxR/DDTqYNk6uXn8BJMEcncLSpMbf/XV1aS0jAjYwn98uvVCiAywQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1157,10 +1157,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.42.0_eslint@8.26.0+typescript@4.6.4
+      '@typescript-eslint/parser': 5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4
       '@typescript-eslint/scope-manager': 5.42.0
-      '@typescript-eslint/type-utils': 5.42.0_eslint@8.26.0+typescript@4.6.4
-      '@typescript-eslint/utils': 5.42.0_eslint@8.26.0+typescript@4.6.4
+      '@typescript-eslint/type-utils': 5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4
+      '@typescript-eslint/utils': 5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4
       debug: 4.3.4
       eslint: 8.26.0
       ignore: 5.2.0
@@ -1173,7 +1173,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.42.0_eslint@8.26.0+typescript@4.6.4:
+  /@typescript-eslint/parser/5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4:
     resolution: {integrity: sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1209,7 +1209,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.42.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.42.0_eslint@8.26.0+typescript@4.6.4:
+  /@typescript-eslint/type-utils/5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4:
     resolution: {integrity: sha512-HW14TXC45dFVZxnVW8rnUGnvYyRC0E/vxXShFCthcC9VhVTmjqOmtqj6H5rm9Zxv+ORxKA/1aLGD7vmlLsdlOg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1220,7 +1220,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.42.0_typescript@4.6.4
-      '@typescript-eslint/utils': 5.42.0_eslint@8.26.0+typescript@4.6.4
+      '@typescript-eslint/utils': 5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4
       debug: 4.3.4
       eslint: 8.26.0
       tsutils: 3.21.0_typescript@4.6.4
@@ -1281,7 +1281,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.27.1_eslint@8.26.0+typescript@4.6.4:
+  /@typescript-eslint/utils/5.27.1_t64u7vh5pvkzkn6jnkohfgcmb4:
     resolution: {integrity: sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1299,7 +1299,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils/5.42.0_eslint@8.26.0+typescript@4.6.4:
+  /@typescript-eslint/utils/5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4:
     resolution: {integrity: sha512-JZ++3+h1vbeG1NUECXQZE3hg0kias9kOtcQr3+JVQ3whnjvKuMyktJAAIj6743OeNPnGBmjj7KEmiDL7qsdnCQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2467,7 +2467,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3_eaddb778b94e5ad32584e39df25f9d4a:
+  /eslint-module-utils/2.7.3_5lo3o6fzjznngjme4oo7ex45ji:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2485,7 +2485,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.42.0_eslint@8.26.0+typescript@4.6.4
+      '@typescript-eslint/parser': 5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -2493,7 +2493,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import/2.26.0_e8080e8dfc6eb6c2d798d3189bb964d9:
+  /eslint-plugin-import/2.26.0_5aea5dp4n23mfv4y2mmjxole3e:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -2503,14 +2503,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.42.0_eslint@8.26.0+typescript@4.6.4
+      '@typescript-eslint/parser': 5.42.0_t64u7vh5pvkzkn6jnkohfgcmb4
       array-includes: 3.1.4
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.26.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_eaddb778b94e5ad32584e39df25f9d4a
+      eslint-module-utils: 2.7.3_5lo3o6fzjznngjme4oo7ex45ji
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -2524,7 +2524,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest/26.9.0_89d29be57054bf0fbb433898cb8f1a9d:
+  /eslint-plugin-jest/26.9.0_rhjjxzlqks7q7o2dhcmmxdy2tu:
     resolution: {integrity: sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2537,8 +2537,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.42.0_cf2448fba32f5cacd6a7d2d9b63f7cb6
-      '@typescript-eslint/utils': 5.27.1_eslint@8.26.0+typescript@4.6.4
+      '@typescript-eslint/eslint-plugin': 5.42.0_z4ser65df5okzvvh2lm3mp34wy
+      '@typescript-eslint/utils': 5.27.1_t64u7vh5pvkzkn6jnkohfgcmb4
       eslint: 8.26.0
     transitivePeerDependencies:
       - supports-color
@@ -2553,7 +2553,7 @@ packages:
       eslint: 8.26.0
     dev: true
 
-  /eslint-plugin-prettier/4.2.1_e1e64d52f64ca2fc626d6040e4e5aafc:
+  /eslint-plugin-prettier/4.2.1_4hte2uxwjsrpyytnmbaojznk7q:
     resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -3894,7 +3894,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /jest-runner-eslint/1.1.0_eslint@8.26.0+jest@26.6.3:
+  /jest-runner-eslint/1.1.0_jest@26.6.3:
     resolution: {integrity: sha512-XAQnEIuaZ/wHU8YVR4AEka5FBg3P+fnKd/upk8D9lxhejsclgai5gle7Ay4eLQ1+mlh2y5Ya3/AmfYz8FFZKJQ==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
@@ -3905,7 +3905,6 @@ packages:
       cosmiconfig: 6.0.0
       create-jest-runner: 0.6.0
       dot-prop: 5.3.0
-      eslint: 8.26.0
       jest: 26.6.3
     dev: true
 
@@ -5510,7 +5509,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /ts-jest/26.5.6_jest@26.6.3+typescript@4.6.4:
+  /ts-jest/26.5.6_ip4jai7pxkumsngma2fb7ud2tm:
     resolution: {integrity: sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==}
     engines: {node: '>= 10'}
     hasBin: true

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -24,11 +24,11 @@ module.exports = {
     onboarding: false,
     requireConfig: false,
     constraints: {
-        pnpm: "< 7.0.0",
+        pnpm: "< 8.0.0",
     },
     allowedPostUpgradeCommands: [".*"],
     postUpgradeTasks: {
-        commands: ["npm i -g pnpm@'< 7.0.0' && pnpm install && pnpm build"],
+        commands: ["npm i -g pnpm@7.9.5 && pnpm install && pnpm build"],
         fileFilters: ["**/index.js"],
         executionMode: "update"
     }

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -24,7 +24,7 @@ module.exports = {
     onboarding: false,
     requireConfig: false,
     constraints: {
-        pnpm: "< 8.0.0",
+        pnpm: "7.9.5",
     },
     allowedPostUpgradeCommands: [".*"],
     postUpgradeTasks: {


### PR DESCRIPTION
To make it easier to work with both step packages and portal, we are making all step package repos use pnpm v7.9.5 which is the same as the portal.