### PR TITLE
Update versioning PR workflow to use the correct github token

### DIFF
--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -48,4 +48,4 @@ jobs:
         with:
           version: pnpm run ci:version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_GITHUB_TOKEN }}


### PR DESCRIPTION
Updating Create Versioning PR workflow to use a GitHub token with the correct permissions so any created PR will run the checks.