### PR TITLE
Update packages to use @octopusdeploy/ prefix

### DIFF
--- a/.changeset/brave-kangaroos-sip.md
+++ b/.changeset/brave-kangaroos-sip.md
@@ -1,0 +1,8 @@
+---
+"@octopusdeploy/add-changeset": patch
+"@octopusdepoy/current-branch-name": patch
+"@octopusdeploy/extract-package-details": patch
+"@octopusdeploy/find-and-replace-all": patch
+---
+
+Updating package names to include @octopusdeploy/ prefix for security reasons.

--- a/.changeset/brave-kangaroos-sip.md
+++ b/.changeset/brave-kangaroos-sip.md
@@ -1,6 +1,6 @@
 ---
 "@octopusdeploy/add-changeset": patch
-"@octopusdepoy/current-branch-name": patch
+"@octopusdeploy/current-branch-name": patch
 "@octopusdeploy/extract-package-details": patch
 "@octopusdeploy/find-and-replace-all": patch
 ---

--- a/packages/add-changeset/CHANGELOG.md
+++ b/packages/add-changeset/CHANGELOG.md
@@ -1,4 +1,4 @@
-# add-changeset
+# @octopusdeploy/add-changeset
 
 ## 0.2.0
 

--- a/packages/add-changeset/package.json
+++ b/packages/add-changeset/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "add-changeset",
+  "name": "@octopusdeploy/add-changeset",
   "version": "0.2.0",
   "description": "Adds a changeset containing one or more projects",
   "main": "index.js",

--- a/packages/current-branch-name/CHANGELOG.md
+++ b/packages/current-branch-name/CHANGELOG.md
@@ -1,4 +1,4 @@
-# current-branch-name
+# @octopusdeploy/current-branch-name
 
 ## 0.1.0
 

--- a/packages/current-branch-name/package.json
+++ b/packages/current-branch-name/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "current-branch-name",
+  "name": "@octopusdepoy/current-branch-name",
   "version": "0.1.0",
   "description": "This gets the current branch name or tag sanitised as needed",
   "main": "index.js",

--- a/packages/current-branch-name/package.json
+++ b/packages/current-branch-name/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@octopusdepoy/current-branch-name",
+  "name": "@octopusdeploy/current-branch-name",
   "version": "0.1.0",
   "description": "This gets the current branch name or tag sanitised as needed",
   "main": "index.js",

--- a/packages/extract-package-details/CHANGELOG.md
+++ b/packages/extract-package-details/CHANGELOG.md
@@ -1,4 +1,4 @@
-# extract-package-details
+# @octopusdeploy/extract-package-details
 
 ## 0.2.0
 

--- a/packages/extract-package-details/package.json
+++ b/packages/extract-package-details/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "extract-package-details",
+  "name": "@octopusdeploy/extract-package-details",
   "version": "0.2.0",
   "description": "Extracts details from a package.json file",
   "main": "index.js",

--- a/packages/find-and-replace-all/CHANGELOG.md
+++ b/packages/find-and-replace-all/CHANGELOG.md
@@ -1,4 +1,4 @@
-# find-and-replace-all
+# @octopusdeploy/find-and-replace-all
 
 ## 0.2.0
 

--- a/packages/find-and-replace-all/package.json
+++ b/packages/find-and-replace-all/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "find-and-replace-all",
+  "name": "@octopusdeploy/find-and-replace-all",
   "version": "0.2.0",
   "description": "Find and replace all instances of a string",
   "main": "index.js",


### PR DESCRIPTION
As a result of fixing the [security vulnerability in step-package-template](https://github.com/OctopusDeploy/step-package-template/pull/108), we decided it would be best to prefix all our step packages with `@octopusdeploy/` to ensure that they are all scoped to the company.