### PR TITLE
Update to `actions/setup-node@v4`

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -29,7 +29,7 @@ jobs:
           version: 8.15.9
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "20.19.0"
           cache: "pnpm"
@@ -70,7 +70,7 @@ jobs:
           version: 8.15.9
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "20.19.0"
           cache: "pnpm"

--- a/.github/workflows/create-versioning-pr.yml
+++ b/.github/workflows/create-versioning-pr.yml
@@ -30,7 +30,7 @@ jobs:
           version: 8.15.9
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "20.19.0"
           cache: "pnpm"


### PR DESCRIPTION
Version 2 of `actions/setup-node` relies on an old version of `actions/cache` which no longer works, and [throws errors as of 15th April 2025](https://github.com/actions/setup-node/issues/1275). 

This PR updates to v4 of the action.