### PR TITLE
Update packages to use @types/node 24

### DIFF
--- a/packages/add-changeset/package.json
+++ b/packages/add-changeset/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/glob": "7.2.0",
     "@types/jest": "27.5.2",
-    "@types/node": "20.17.58",
+    "@types/node": "24.1.0",
     "esbuild": "0.14.54",
     "eslint": "8.57.1",
     "typescript": "4.9.5",

--- a/packages/current-branch-name/package.json
+++ b/packages/current-branch-name/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "20.17.58",
+    "@types/node": "24.1.0",
     "esbuild": "0.14.54",
     "eslint": "8.57.1",
     "jest": "26.6.3",

--- a/packages/extract-package-details/package.json
+++ b/packages/extract-package-details/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "20.17.58",
+    "@types/node": "24.1.0",
     "esbuild": "0.14.54",
     "eslint": "8.57.1",
     "jest": "26.6.3",

--- a/packages/find-and-replace-all/package.json
+++ b/packages/find-and-replace-all/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "27.5.2",
-    "@types/node": "20.17.58",
+    "@types/node": "24.1.0",
     "esbuild": "0.14.54",
     "eslint": "8.57.1",
     "jest": "26.6.3",

--- a/packages/shared-action-utils/package.json
+++ b/packages/shared-action-utils/package.json
@@ -14,7 +14,7 @@
     "glob": "7.2.3"
   },
   "devDependencies": {
-    "@types/node": "20.17.58",
+    "@types/node": "24.1.0",
     "@types/glob": "7.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: 27.5.2
         version: 27.5.2
       '@types/node':
-        specifier: 20.17.58
-        version: 20.17.58
+        specifier: 24.1.0
+        version: 24.1.0
       esbuild:
         specifier: 0.14.54
         version: 0.14.54
@@ -112,8 +112,8 @@ importers:
         specifier: 27.5.2
         version: 27.5.2
       '@types/node':
-        specifier: 20.17.58
-        version: 20.17.58
+        specifier: 24.1.0
+        version: 24.1.0
       esbuild:
         specifier: 0.14.54
         version: 0.14.54
@@ -149,8 +149,8 @@ importers:
         specifier: 27.5.2
         version: 27.5.2
       '@types/node':
-        specifier: 20.17.58
-        version: 20.17.58
+        specifier: 24.1.0
+        version: 24.1.0
       esbuild:
         specifier: 0.14.54
         version: 0.14.54
@@ -186,8 +186,8 @@ importers:
         specifier: 27.5.2
         version: 27.5.2
       '@types/node':
-        specifier: 20.17.58
-        version: 20.17.58
+        specifier: 24.1.0
+        version: 24.1.0
       esbuild:
         specifier: 0.14.54
         version: 0.14.54
@@ -229,8 +229,8 @@ importers:
         specifier: 7.2.0
         version: 7.2.0
       '@types/node':
-        specifier: 20.17.58
-        version: 20.17.58
+        specifier: 24.1.0
+        version: 24.1.0
 
 packages:
 
@@ -1018,7 +1018,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       chalk: 4.1.2
       jest-message-util: 26.6.2
       jest-util: 26.6.2
@@ -1034,7 +1034,7 @@ packages:
       '@jest/test-result': 26.6.2
       '@jest/transform': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       exit: 0.1.2
@@ -1071,7 +1071,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       jest-mock: 26.6.2
     dev: true
 
@@ -1081,7 +1081,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@sinonjs/fake-timers': 6.0.1
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       jest-message-util: 26.6.2
       jest-mock: 26.6.2
       jest-util: 26.6.2
@@ -1195,7 +1195,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       '@types/yargs': 15.0.19
       chalk: 4.1.2
     dev: true
@@ -1349,13 +1349,13 @@ packages:
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
     dev: true
 
   /@types/graceful-fs@4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -1397,10 +1397,10 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@20.17.58:
-    resolution: {integrity: sha512-UvxetCgGwZ9HmsgGZ2tpStt6CiFU1bu28ftHWpDyfthsCt7OHXas0C7j0VgO3gBq8UHKI785wXmtcQVhLekcRg==}
+  /@types/node@24.1.0:
+    resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 7.8.0
     dev: true
 
   /@types/normalize-package-data@2.4.1:
@@ -4393,7 +4393,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       jest-mock: 26.6.2
       jest-util: 26.6.2
       jsdom: 16.7.0
@@ -4411,7 +4411,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/fake-timers': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       jest-mock: 26.6.2
       jest-util: 26.6.2
     dev: true
@@ -4446,7 +4446,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
@@ -4472,7 +4472,7 @@ packages:
       '@jest/source-map': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       chalk: 4.1.2
       co: 4.6.0
       expect: 26.6.2
@@ -4541,7 +4541,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
     dev: true
 
   /jest-pnp-resolver@1.2.2(jest-resolve@26.6.2):
@@ -4609,7 +4609,7 @@ packages:
       '@jest/environment': 26.6.2
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       chalk: 4.1.2
       emittery: 0.7.2
       exit: 0.1.2
@@ -4677,7 +4677,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       graceful-fs: 4.2.10
     dev: true
 
@@ -4710,7 +4710,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       chalk: 4.1.2
       graceful-fs: 4.2.10
       is-ci: 2.0.0
@@ -4735,7 +4735,7 @@ packages:
     dependencies:
       '@jest/test-result': 26.6.2
       '@jest/types': 26.6.2
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 26.6.2
@@ -4754,7 +4754,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.17.58
+      '@types/node': 24.1.0
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -6411,8 +6411,8 @@ packages:
       which-boxed-primitive: 1.1.1
     dev: true
 
-  /undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  /undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
     dev: true
 
   /union-value@1.0.1:


### PR DESCRIPTION
## Background 🌇  
Node 24 is the latest LTS release. We will need all our current GitHub Actions to be upgraded to it.

## What's this? 🌵 

Following on from https://github.com/OctopusDeploy/util-actions/pull/248, this PR updates `@types/node` to use node 24. I've gone with 24.1.0 as that's the latest 'current tag' [listed by the `@types/node` package](https://www.npmjs.com/package/@types/node?activeTab=versions) for version 24. 

## Testing 🧪 
This has been tested manually on the ephemeral environments demo instance using a modified version of one of our demo workflows. You can find the workflow code [here](https://github.com/OctopusDeploy/ephemeral-environments-demo/pull/112/files) and the successful runs [here](https://github.com/OctopusDeploy/ephemeral-environments-demo/actions/runs/20155627494/job/57857584297). 

## How to review? 🔍 
☑️ Is there anything else I might have missed?
👌 Don't worry, this repo doesn't use conventional commit messages ;)

[sc-125029]