### PR TITLE
chore: Fix Renovate PR builds

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -34,7 +34,7 @@ module.exports = {
     },
     allowedPostUpgradeCommands: [".*"],
     postUpgradeTasks: {
-        commands: ["npm i -g pnpm@8.15.9 && pnpm install && pnpm build"],
+        commands: ["npm i -g pnpm@8.15.9", "pnpm install", "pnpm build"],
         fileFilters: ["**/index.js"],
         executionMode: "update",
     },


### PR DESCRIPTION
Our Renovate PRs are displaying the following error:

```
Command failed: npm i -g pnpm@8.15.9 && pnpm install && pnpm build                                                                                                                                                                                                           
npm error code EINVALIDTAGNAME                                                                                                                                                                                                                                               
npm error Invalid tag name "&&" of package "&&": Tags may not have any characters that encodeURIComponent encodes.                                                                                                                                                           
npm error A complete log of this run can be found in: /home/ubuntu/.npm/_logs/2026-03-17T00_18_08_462Z-debug-0.log  
```

Example: https://github.com/OctopusDeploy/util-actions/pull/267#issuecomment-4301906096

The `postUpgradeTasks.commands` field takes an array of commands.