### PR TITLE
chore: Fix Renovate run

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v39.2.4
+        uses: renovatebot/github-action@v46.1.10
         with:
           configurationFile: renovate-config.js
           token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -34,7 +34,7 @@ module.exports = {
     },
     allowedPostUpgradeCommands: [".*"],
     postUpgradeTasks: {
-        commands: ["npm i -g pnpm@8.15.9", "pnpm install", "pnpm build"],
+        commands: ["npm i -g pnpm@8.15.9", "pnpm install", "pnpm build", "rm -rf node_modules packages/*/node_modules"],
         fileFilters: ["**/index.js"],
         executionMode: "update",
     },


### PR DESCRIPTION
Our Renovate action runs were getting stuck on the second processed branch because `pnpm install --lockfile-only` wouldn't run with a populated `node_modules` directory which exists in order to `pnpm build` in `postUpgradeTasks`.

Example failure: https://github.com/OctopusDeploy/util-actions/actions/runs/24867581881

Example fixed: https://github.com/OctopusDeploy/util-actions/actions/runs/24870503297