### PR TITLE
fix(renovate): Update renovate to install pnpm

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -22,19 +22,25 @@ module.exports = {
     repositories: ["OctopusDeploy/util-actions"],
     packageRules: [
         {
-        matchDatasources: ['npm'],
-        minimumReleaseAge: '2 days'
+            matchDatasources: ['npm'],
+            minimumReleaseAge: '2 days'
+        },
+        {
+            // Ignore workspace packages that aren't published to npm
+            matchPackageNames: ['@octopusdeploy/shared-action-utils'],
+            enabled: false
         }
     ],
     timezone: "Australia/Brisbane",
     onboarding: false,
     requireConfig: false,
+    binarySource: "install",
     constraints: {
         pnpm: "8.15.9",
     },
     allowedPostUpgradeCommands: [".*"],
     postUpgradeTasks: {
-        commands: ["npm i -g pnpm@8.15.9", "pnpm install", "pnpm build", "rm -rf node_modules packages/*/node_modules"],
+        commands: ["pnpm install", "pnpm build", "rm -rf node_modules packages/*/node_modules"],
         fileFilters: ["**/index.js"],
         executionMode: "update",
     },


### PR DESCRIPTION
# Background

Renovate has failed a build due to being unable to find pnpm. Another failure of not finding a shared utils package was found

# Fix

Update renovate config to install pnpm before running it
Ignore the shared utils package if it wasn't found

# Result

Successfull run: https://github.com/OctopusDeploy/util-actions/actions/runs/25138594181