### PR TITLE
docs: Mark repo as archived and no longer supported

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+  pull_request:
+
   schedule:
     - cron: "0 20 * * *"
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,12 +5,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "README.md"
-
-  pull_request:
-    paths-ignore:
-      - "README.md"
 
   schedule:
     - cron: "0 20 * * *"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # util-actions
 
+> **⚠️ Archived:** This repository has been archived and is no longer supported. It is not maintained and will not receive updates, bug fixes, or security patches.
+
 A set of utility actions for use in GitHub action workflows.
 
 ## Usage


### PR DESCRIPTION
We are deprecating this action repository.

This change adds a notice to the top of the README indicating this repository has been archived and is no longer supported. Follows a similar approach to deprecation that GitHub did for the [create release action](https://github.com/actions/create-release#github-action---releases-api).

Part of BMBB-680